### PR TITLE
Structure2vec now takes a Model as a parameter

### DIFF
--- a/s2v_scheduling.py
+++ b/s2v_scheduling.py
@@ -59,7 +59,7 @@ def edge_weights(mu_all, node, nd_edges):
     return mu_N, weights
 
 
-def structure2vec(graph, p_dim=128, t=4):  # t is iterations which is rec'd as 4
+def structure2vec(s2v: Model, graph, p_dim=128, t=4):  # t is iterations which is rec'd as 4
     node_list = copy.deepcopy(graph)
     ser_num_list = []
 
@@ -69,7 +69,6 @@ def structure2vec(graph, p_dim=128, t=4):  # t is iterations which is rec'd as 4
     node_num = len(node_list.nodedict)
 
     mu_all = torch.zeros(node_num, p_dim)
-    s2v = Model(p_dim)
     #x_all = []
 
     for _ in range(t):

--- a/training.py
+++ b/training.py
@@ -72,7 +72,7 @@ class Agent:
             actionID: the nodeID of the selected node
             action: the embedding for the corresponding nodeID
         """
-        graphEmbeddings = Model.structure2vec(graph) #FIXME won't use the correct model
+        graphEmbeddings = Model.structure2vec(self.model, graph) #FIXME won't use the correct model
         
         qValueDict = {}
         for nodeID in graph.getActions():


### PR DESCRIPTION
The original structure2vec created an object of type Model in the function body. I have changed it to `def structure2vec(s2v: Model, graph, p_dim=128, t=4):`  so the function always uses the correct Model object (the one from the Agent class).

I now call the function during training using  `graphEmbeddings = Model.structure2vec(self.model, graph)`